### PR TITLE
feat: Distinguish deleted subscribers from errors in drip processing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,16 +140,3 @@ printenv | grep -E '^(LISTMONK_|LOG_LEVEL|DRY_RUN|DATABASE_)' > /etc/environment
 | Quick PayPal Payments (QPP) | 5623 | quick-paypal-payments |
 
 Free-only plugins (no Freemius): SUE, SWEGTS, CFCS, SSGM, RSHFD, MMT, LHF, FS, AUM
-
----
-
-Issue to solve: https://github.com/alanef/flowmonk/issues/1
-Your prepared branch: issue-1-7a36e3887c96
-Your prepared working directory: /tmp/gh-issue-solver-1767650849546
-Your forked repository: konard/alanef-flowmonk
-Original repository (upstream): alanef/flowmonk
-
-Proceed.
-
-
-Run timestamp: 2026-01-05T22:07:38.910Z

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -140,3 +140,16 @@ printenv | grep -E '^(LISTMONK_|LOG_LEVEL|DRY_RUN|DATABASE_)' > /etc/environment
 | Quick PayPal Payments (QPP) | 5623 | quick-paypal-payments |
 
 Free-only plugins (no Freemius): SUE, SWEGTS, CFCS, SSGM, RSHFD, MMT, LHF, FS, AUM
+
+---
+
+Issue to solve: https://github.com/alanef/flowmonk/issues/1
+Your prepared branch: issue-1-7a36e3887c96
+Your prepared working directory: /tmp/gh-issue-solver-1767650849546
+Your forked repository: konard/alanef-flowmonk
+Original repository (upstream): alanef/flowmonk
+
+Proceed.
+
+
+Run timestamp: 2026-01-05T22:07:38.910Z

--- a/campaign-list-builder/public/index.php
+++ b/campaign-list-builder/public/index.php
@@ -861,7 +861,8 @@ function handleApi(string $uri, string $method): void
                 if (!$isActive) {
                     $blockReasons[] = 'Subscriber is inactive for this product';
                 }
-                if (in_array($stage, ['complete', 'stopped', 'error', 'none', 'imported', ''])) {
+                // FA-18: Added 'deleted' for subscribers removed from Listmonk
+                if (in_array($stage, ['complete', 'stopped', 'error', 'deleted', 'none', 'imported', ''])) {
                     $blockReasons[] = "Stage is inactive: '" . ($stage ?: 'empty') . "'";
                 }
                 if (empty($nextDateStr)) {

--- a/drip-controller/src/DripProcessor.php
+++ b/drip-controller/src/DripProcessor.php
@@ -150,6 +150,13 @@ class DripProcessor
                         return 'skipped';
                     }
                 }
+            } catch (SubscriberNotFoundException $e) {
+                // FA-18: Subscriber was deleted from Listmonk - mark as 'deleted' not 'error'
+                $this->logger->info("[$email] Subscriber deleted from Listmonk (ID: $listmonkId) - marking drip as deleted");
+                if (!$this->dryRun) {
+                    $this->db->updateDrip($dripId, ['stage' => 'deleted', 'next_send' => null]);
+                }
+                return 'skipped';
             } catch (Exception $e) {
                 $this->logger->warn("[$email] Could not fetch subscriber from Listmonk: " . $e->getMessage());
                 // Continue without Listmonk check if we can't reach it

--- a/drip-controller/src/DunningProcessor.php
+++ b/drip-controller/src/DunningProcessor.php
@@ -13,6 +13,8 @@
  * - Day 21: Blocklist subscriber (dunning_blocklist)
  */
 
+require_once __DIR__ . '/SubscriberNotFoundException.php';
+
 class DunningProcessor
 {
     private ListmonkClient $client;
@@ -201,6 +203,13 @@ class DunningProcessor
                 $this->logger->info("[$email] Subscriber confirmed on list $listId - cleared dunning");
                 return true;
             }
+        } catch (SubscriberNotFoundException $e) {
+            // FA-18: Subscriber was deleted from Listmonk - clear dunning
+            $this->logger->info("[$email] Subscriber deleted from Listmonk (ID: $listmonkId) - cleared dunning");
+            if (!$this->dryRun) {
+                $this->db->deleteDunning($subscriberId, $listId);
+            }
+            return true; // Return true since we cleared the dunning
         } catch (Exception $e) {
             $this->logger->warn("[$email] Could not check confirmation status: " . $e->getMessage());
         }
@@ -262,6 +271,10 @@ class DunningProcessor
             $this->logger->info("[$email] Initiated dunning for list $unconfirmedListId, first reminder: " . $firstReminderDate->format('Y-m-d H:i:s'));
             return true;
 
+        } catch (SubscriberNotFoundException $e) {
+            // FA-18: Subscriber was deleted - no action needed, just skip
+            $this->logger->debug("[$email] Subscriber deleted from Listmonk (ID: $listmonkId) - skipping dunning initiation");
+            return false;
         } catch (Exception $e) {
             $this->logger->warn("[$email] Could not check for dunning initiation: " . $e->getMessage());
         }
@@ -321,6 +334,13 @@ class DunningProcessor
                     $this->logger->info("[$email] Subscriber confirmed - cleared dunning");
                     return 'confirmed';
                 }
+            } catch (SubscriberNotFoundException $e) {
+                // FA-18: Subscriber was deleted from Listmonk - clear dunning
+                $this->logger->info("[$email] Subscriber deleted from Listmonk (ID: $listmonkId) - cleared dunning");
+                if (!$this->dryRun) {
+                    $this->db->deleteDunning($subscriberId, $listId);
+                }
+                return 'skipped';
             } catch (Exception $e) {
                 $this->logger->warn("[$email] Could not check confirmation: " . $e->getMessage());
             }
@@ -490,17 +510,24 @@ class DunningProcessor
             return true;
         }
 
-        // Set status to blocklisted via Listmonk API
-        $success = $this->client->setSubscriberStatus($listmonkId, 'blocklisted');
+        try {
+            // Set status to blocklisted via Listmonk API
+            $success = $this->client->setSubscriberStatus($listmonkId, 'blocklisted');
 
-        if ($success) {
-            // Delete the dunning record since we're done
+            if ($success) {
+                // Delete the dunning record since we're done
+                $this->db->deleteDunning($subscriberId, $listId);
+                $this->logger->info("[$email] Blocklisted after 21 days unconfirmed");
+            } else {
+                $this->logger->error("[$email] Failed to blocklist subscriber");
+            }
+
+            return $success;
+        } catch (SubscriberNotFoundException $e) {
+            // FA-18: Subscriber was already deleted - clear dunning and consider it done
+            $this->logger->info("[$email] Subscriber deleted from Listmonk (ID: $listmonkId) - cleared dunning (no blocklist needed)");
             $this->db->deleteDunning($subscriberId, $listId);
-            $this->logger->info("[$email] Blocklisted after 21 days unconfirmed");
-        } else {
-            $this->logger->error("[$email] Failed to blocklist subscriber");
+            return true;
         }
-
-        return $success;
     }
 }

--- a/drip-controller/src/ListmonkClient.php
+++ b/drip-controller/src/ListmonkClient.php
@@ -6,6 +6,8 @@
  * subscriber queries, attribute updates, and transactional emails.
  */
 
+require_once __DIR__ . '/SubscriberNotFoundException.php';
+
 class ListmonkClient
 {
     private string $baseUrl;
@@ -109,10 +111,36 @@ class ListmonkClient
 
     /**
      * Get a single subscriber by ID
+     *
+     * @throws SubscriberNotFoundException if subscriber does not exist (404)
+     * @throws RuntimeException for other API errors
      */
     public function getSubscriber(int $id): array
     {
-        return $this->request('GET', "subscribers/$id");
+        try {
+            return $this->request('GET', "subscribers/$id");
+        } catch (RuntimeException $e) {
+            // FA-18: Detect 404 "subscriber not found" and throw specific exception
+            if ($this->isSubscriberNotFoundError($e->getMessage())) {
+                throw new SubscriberNotFoundException($id, $e->getMessage());
+            }
+            throw $e;
+        }
+    }
+
+    /**
+     * Check if an error message indicates a subscriber was not found
+     * FA-18: Detect deleted subscribers distinctly from other errors
+     */
+    private function isSubscriberNotFoundError(string $message): bool
+    {
+        // Listmonk returns HTTP 400 with message containing "subscriber not found"
+        // when the subscriber ID doesn't exist
+        return (
+            stripos($message, 'subscriber not found') !== false ||
+            stripos($message, 'record not found') !== false ||
+            preg_match('/API error \(404\)/i', $message)
+        );
     }
 
     /**

--- a/drip-controller/src/SequenceManager.php
+++ b/drip-controller/src/SequenceManager.php
@@ -201,10 +201,11 @@ class SequenceManager
 
     /**
      * Check if a stage indicates the sequence is complete or stopped
+     * FA-18: Added 'deleted' for subscribers removed from Listmonk
      */
     public function isInactiveStage(string $stage): bool
     {
-        return in_array($stage, ['complete', 'stopped', 'error', 'none', 'imported', '']);
+        return in_array($stage, ['complete', 'stopped', 'error', 'deleted', 'none', 'imported', '']);
     }
 
     /**

--- a/drip-controller/src/SubscriberNotFoundException.php
+++ b/drip-controller/src/SubscriberNotFoundException.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * Subscriber Not Found Exception
+ *
+ * FA-18: Thrown when a subscriber has been deleted from Listmonk.
+ * This allows the drip processor to distinguish between "subscriber gone"
+ * and actual API errors.
+ */
+
+class SubscriberNotFoundException extends RuntimeException
+{
+    private int $subscriberId;
+
+    public function __construct(int $subscriberId, string $message = '')
+    {
+        $this->subscriberId = $subscriberId;
+        parent::__construct($message ?: "Subscriber $subscriberId not found in Listmonk (deleted or does not exist)");
+    }
+
+    public function getSubscriberId(): int
+    {
+        return $this->subscriberId;
+    }
+}

--- a/shared/src/SequenceDatabase.php
+++ b/shared/src/SequenceDatabase.php
@@ -946,7 +946,7 @@ class SequenceDatabase
               AND d.next_send <= ?
               AND d.is_active = 1
               AND d.stage IS NOT NULL
-              AND d.stage NOT IN ('complete', 'error', 'stopped', 'none', 'imported')
+              AND d.stage NOT IN ('complete', 'error', 'stopped', 'deleted', 'none', 'imported')
             ORDER BY d.next_send ASC
         ");
         $stmt->execute([$now]);
@@ -967,7 +967,7 @@ class SequenceDatabase
             WHERE d.next_send IS NOT NULL
               AND d.is_active = 1
               AND d.stage IS NOT NULL
-              AND d.stage NOT IN ('complete', 'error', 'stopped', 'none', 'imported')
+              AND d.stage NOT IN ('complete', 'error', 'stopped', 'deleted', 'none', 'imported')
         ";
         $params = [];
 
@@ -996,7 +996,7 @@ class SequenceDatabase
                 p.name as product_name,
                 d.status,
                 COUNT(*) as count,
-                SUM(CASE WHEN d.stage IN ('complete', 'error', 'stopped') THEN 0 ELSE 1 END) as active_count
+                SUM(CASE WHEN d.stage IN ('complete', 'error', 'stopped', 'deleted') THEN 0 ELSE 1 END) as active_count
             FROM subscriber_drips d
             JOIN products p ON d.product_id = p.id
             GROUP BY d.product_id, d.status
@@ -1269,7 +1269,7 @@ class SequenceDatabase
                 WHERE product_id = ?
                   AND is_active = 1
                   AND stage IS NOT NULL
-                  AND stage NOT IN ('complete', 'stopped', 'error', 'none', 'imported')
+                  AND stage NOT IN ('complete', 'stopped', 'error', 'deleted', 'none', 'imported')
             ");
             $stmt->execute([$productId]);
             $inQueue = (int)$stmt->fetchColumn();
@@ -1282,7 +1282,7 @@ class SequenceDatabase
                   AND next_send IS NOT NULL
                   AND next_send <= ?
                   AND stage IS NOT NULL
-                  AND stage NOT IN ('complete', 'stopped', 'error', 'none', 'imported')
+                  AND stage NOT IN ('complete', 'stopped', 'error', 'deleted', 'none', 'imported')
             ");
             $stmt->execute([$productId, $now]);
             $dueNow = (int)$stmt->fetchColumn();
@@ -1341,7 +1341,7 @@ class SequenceDatabase
             case 'due':
                 $whereConditions[] = "d.next_send IS NOT NULL AND d.next_send != '' AND d.next_send <= ?";
                 $whereConditions[] = "d.is_active = 1";
-                $whereConditions[] = "d.stage IS NOT NULL AND d.stage != '' AND d.stage NOT IN ('complete', 'stopped', 'error', 'none', 'imported')";
+                $whereConditions[] = "d.stage IS NOT NULL AND d.stage != '' AND d.stage NOT IN ('complete', 'stopped', 'error', 'deleted', 'none', 'imported')";
                 $params[] = $now;
                 break;
             case 'error':
@@ -1353,7 +1353,7 @@ class SequenceDatabase
             case 'active':
             default:
                 $whereConditions[] = "d.is_active = 1";
-                $whereConditions[] = "d.stage IS NOT NULL AND d.stage != '' AND d.stage NOT IN ('complete', 'stopped', 'error', 'none', 'imported')";
+                $whereConditions[] = "d.stage IS NOT NULL AND d.stage != '' AND d.stage NOT IN ('complete', 'stopped', 'error', 'deleted', 'none', 'imported')";
                 break;
         }
 
@@ -1501,7 +1501,7 @@ class SequenceDatabase
                 WHERE product_id = ?
                   AND is_active = 1
                   AND stage IS NOT NULL
-                  AND stage NOT IN ('complete', 'stopped', 'error', 'none', 'imported')
+                  AND stage NOT IN ('complete', 'stopped', 'error', 'deleted', 'none', 'imported')
             ");
             $stmt->execute([$productId]);
             $productData['total_active'] = (int)$stmt->fetchColumn();
@@ -1520,14 +1520,16 @@ class SequenceDatabase
             $stageCounts = $stmt->fetchAll();
 
             // Track terminal state counts to add at end
-            $terminalCounts = ['complete' => 0, 'stopped' => 0, 'error' => 0];
+            // FA-18: Added 'deleted' as a terminal state
+            $terminalCounts = ['complete' => 0, 'stopped' => 0, 'error' => 0, 'deleted' => 0];
 
             foreach ($stageCounts as $row) {
                 $stage = $row['stage'] ?? 'unknown';
                 $count = (int)$row['count'];
 
                 // Terminal states: track separately to add at end
-                if (in_array($stage, ['complete', 'stopped', 'error'])) {
+                // FA-18: Added 'deleted' as a terminal state
+                if (in_array($stage, ['complete', 'stopped', 'error', 'deleted'])) {
                     $terminalCounts[$stage] = $count;
                 } else {
                     $productData['funnel'][$stage] = $count;
@@ -1542,9 +1544,11 @@ class SequenceDatabase
             }
 
             // Add terminal states at the end (always show, even if 0)
+            // FA-18: Added 'deleted' for subscribers removed from Listmonk
             $productData['funnel']['complete'] = $terminalCounts['complete'];
             $productData['funnel']['stopped'] = $terminalCounts['stopped'];
             $productData['funnel']['error'] = $terminalCounts['error'];
+            $productData['funnel']['deleted'] = $terminalCounts['deleted'];
 
             // Time-based completions for this product
             $stmt = $this->db->prepare("


### PR DESCRIPTION
## Summary

When a subscriber completely removes themselves from Listmonk (deletes their record entirely), the drip processor now:

- Uses a distinct `deleted` state instead of the generic `error` state
- Logs clearly that the subscriber was deleted, not that an error occurred
- For dunning: clears the dunning record since the subscriber no longer exists

## Changes

1. **New `SubscriberNotFoundException`** (`drip-controller/src/SubscriberNotFoundException.php`)
   - Custom exception for detecting 404 "subscriber not found" API responses

2. **`ListmonkClient` Updates** (`drip-controller/src/ListmonkClient.php`)
   - `getSubscriber()` now throws `SubscriberNotFoundException` for missing subscribers
   - Added `isSubscriberNotFoundError()` helper to detect 404 patterns

3. **`DripProcessor` Updates** (`drip-controller/src/DripProcessor.php`)
   - Catches `SubscriberNotFoundException` and sets stage to `deleted` instead of continuing with potential errors

4. **`DunningProcessor` Updates** (`drip-controller/src/DunningProcessor.php`)
   - All methods that fetch subscribers now handle `SubscriberNotFoundException`
   - For deleted subscribers: clears dunning records immediately

5. **Stage Configuration** (`SequenceManager`, `SequenceDatabase`, UI)
   - Added `deleted` to all inactive/terminal stage lists
   - Stats and queue views correctly exclude `deleted` subscribers from active counts
   - UI recognizes `deleted` as an inactive stage

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Subscriber deleted from Listmonk | Drip marked as `error` | Drip marked as `deleted` |
| API timeout or real error | Drip marked as `error` | Drip marked as `error` (unchanged) |
| Deleted subscriber in dunning | Continued sending | Dunning cleared immediately |
| Log messages | "Could not fetch subscriber" warning | Clear "Subscriber deleted from Listmonk" info |

## Test Plan

- [ ] Delete a test subscriber from Listmonk directly
- [ ] Run drip processor
- [ ] Verify subscriber's drip is marked as `deleted` (not `error`)
- [ ] Verify log shows "Subscriber deleted from Listmonk" message
- [ ] Verify stats page excludes `deleted` from active counts
- [ ] Verify queue page doesn't show `deleted` subscribers as pending

Fixes alanef/flowmonk#1
Related: YouTrack FA-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)